### PR TITLE
Allow functions in dbQuery callback arguments

### DIFF
--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -35,18 +35,21 @@ CLuaArgument::CLuaArgument()
     m_iIndex = -1;
     m_pTableData = NULL;
     m_pUserData = NULL;
+    m_pFunction = NULL;
 }
 
 CLuaArgument::CLuaArgument(const CLuaArgument& Argument, CFastHashMap<CLuaArguments*, CLuaArguments*>* pKnownTables)
 {
     // Initialize and call our = on the argument
     m_pTableData = NULL;
+    m_pFunction = NULL;
     CopyRecursive(Argument, pKnownTables);
 }
 
 CLuaArgument::CLuaArgument(NetBitStreamInterface& bitStream, std::vector<CLuaArguments*>* pKnownTables)
 {
     m_pTableData = NULL;
+    m_pFunction = NULL;
     ReadFromBitStream(bitStream, pKnownTables);
 }
 
@@ -55,6 +58,7 @@ CLuaArgument::CLuaArgument(lua_State* luaVM, int iArgument, CFastHashMap<const v
     // Read the argument out of the lua VM
     m_pTableData = NULL;
     m_iIndex = iArgument;
+    m_pFunction = NULL;
     Read(luaVM, iArgument, pKnownTables);
 }
 
@@ -118,6 +122,13 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
         case LUA_TSTRING:
         {
             m_strString = Argument.m_strString;
+            break;
+        }
+
+        case LUA_TFUNCTION:
+        {
+            if (Argument.m_pFunction)
+                m_pFunction = new CLuaFunctionRef(*Argument.m_pFunction);
             break;
         }
 
@@ -195,6 +206,12 @@ bool CLuaArgument::CompareRecursive(const CLuaArgument& Argument, std::set<CLuaA
         case LUA_TSTRING:
         {
             return m_strString == Argument.m_strString;
+        }
+        case LUA_TFUNCTION:
+        {
+            if (!m_pFunction || !Argument.m_pFunction)
+                return m_pFunction == Argument.m_pFunction;
+            return *m_pFunction == *Argument.m_pFunction;
         }
     }
 
@@ -284,8 +301,7 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
 
             case LUA_TFUNCTION:
             {
-                // TODO: add function reading (has to work inside tables too)
-                m_iType = LUA_TNIL;
+                m_pFunction = new CLuaFunctionRef(luaM_toref(luaVM, iArgument));
                 break;
             }
 
@@ -444,6 +460,15 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
             case LUA_TSTRING:
             {
                 lua_pushlstring(luaVM, m_strString.c_str(), m_strString.length());
+                break;
+            }
+
+            case LUA_TFUNCTION:
+            {
+                if (m_pFunction)
+                    lua_rawgeti(luaVM, LUA_REGISTRYINDEX, m_pFunction->ToInt());
+                else
+                    lua_pushnil(luaVM);
                 break;
             }
         }
@@ -797,6 +822,12 @@ void CLuaArgument::DeleteTableData()
         if (!m_bWeakTableRef)
             delete m_pTableData;
         m_pTableData = NULL;
+    }
+
+    if (m_pFunction)
+    {
+        delete m_pFunction;
+        m_pFunction = NULL;
     }
 }
 

--- a/Client/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Client/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -17,6 +17,7 @@ extern "C"
 #include <net/bitstream.h>
 #include <string>
 #include "json.h"
+#include "CLuaFunctionRef.h"
 
 class CClientEntity;
 class CLuaArguments;
@@ -118,6 +119,7 @@ private:
     SString        m_strString;
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
+    CLuaFunctionRef* m_pFunction;
     bool           m_bWeakTableRef;
 
 #ifdef MTA_DEBUG

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.cpp
@@ -31,12 +31,14 @@ CLuaArgument::CLuaArgument()
     m_iType = LUA_TNIL;
     m_pTableData = NULL;
     m_pUserData = NULL;
+    m_pFunction = NULL;
 }
 
 CLuaArgument::CLuaArgument(const CLuaArgument& Argument, CFastHashMap<CLuaArguments*, CLuaArguments*>* pKnownTables)
 {
     // Initialize and call our = on the argument
     m_pTableData = NULL;
+    m_pFunction = NULL;
     CopyRecursive(Argument, pKnownTables);
 }
 
@@ -44,6 +46,7 @@ CLuaArgument::CLuaArgument(lua_State* luaVM, int iArgument, CFastHashMap<const v
 {
     // Read the argument out of the lua VM
     m_pTableData = NULL;
+    m_pFunction = NULL;
     Read(luaVM, iArgument, pKnownTables);
 }
 
@@ -107,6 +110,13 @@ void CLuaArgument::CopyRecursive(const CLuaArgument& Argument, CFastHashMap<CLua
         case LUA_TSTRING:
         {
             m_strString = Argument.m_strString;
+            break;
+        }
+
+        case LUA_TFUNCTION:
+        {
+            if (Argument.m_pFunction)
+                m_pFunction = new CLuaFunctionRef(*Argument.m_pFunction);
             break;
         }
 
@@ -218,8 +228,7 @@ void CLuaArgument::Read(lua_State* luaVM, int iArgument, CFastHashMap<const void
 
             case LUA_TFUNCTION:
             {
-                // TODO: add function reading (has to work inside tables too)
-                m_iType = LUA_TNIL;
+                m_pFunction = new CLuaFunctionRef(luaM_toref(luaVM, iArgument));
                 break;
             }
 
@@ -294,6 +303,15 @@ void CLuaArgument::Push(lua_State* luaVM, CFastHashMap<CLuaArguments*, int>* pKn
             case LUA_TSTRING:
             {
                 lua_pushlstring(luaVM, m_strString.c_str(), m_strString.length());
+                break;
+            }
+
+            case LUA_TFUNCTION:
+            {
+                if (m_pFunction)
+                    lua_rawgeti(luaVM, LUA_REGISTRYINDEX, m_pFunction->ToInt());
+                else
+                    lua_pushnil(luaVM);
                 break;
             }
         }
@@ -765,6 +783,12 @@ void CLuaArgument::DeleteTableData()
             delete m_pTableData;
         m_pTableData = NULL;
     }
+
+    if (m_pFunction)
+    {
+        delete m_pFunction;
+        m_pFunction = NULL;
+    }
 }
 
 json_object* CLuaArgument::WriteToJSONObject(bool bSerialize, CFastHashMap<CLuaArguments*, unsigned long>* pKnownTables)
@@ -981,6 +1005,12 @@ bool CLuaArgument::IsEqualTo(const CLuaArgument& compareTo, std::set<const CLuaA
         case LUA_TSTRING:
         {
             return m_strString == compareTo.m_strString;
+        }
+        case LUA_TFUNCTION:
+        {
+            if (!m_pFunction || !compareTo.m_pFunction)
+                return m_pFunction == compareTo.m_pFunction;
+            return *m_pFunction == *compareTo.m_pFunction;
         }
     }
 

--- a/Server/mods/deathmatch/logic/lua/CLuaArgument.h
+++ b/Server/mods/deathmatch/logic/lua/CLuaArgument.h
@@ -19,6 +19,7 @@ extern "C"
 }
 #include "../common/CBitStream.h"
 #include "json.h"
+#include "CLuaFunctionRef.h"
 
 class CElement;
 class CLuaArguments;
@@ -120,6 +121,7 @@ private:
     std::string    m_strString;
     void*          m_pUserData;
     CLuaArguments* m_pTableData;
+    CLuaFunctionRef* m_pFunction;
     bool           m_bWeakTableRef;
 
 #ifdef MTA_DEBUG


### PR DESCRIPTION
## Summary
- keep CLuaArgument function references so dbQuery callbacks can receive functions in their argument tables
- mirror CLuaArgument function handling on client side for consistency

## Testing
- `./utils/premake5 gmake`
- `g++ -c Server/mods/deathmatch/logic/lua/CLuaArgument.cpp -std=c++17 -I./Server -I./Shared -I./Shared/sdk -I./Server/mods/deathmatch -I./Server/mods/deathmatch/logic -I./Server/mods/deathmatch/logic/lua -I./Server/sdk -I./vendor -I./vendor/lua/src -I./Shared/mods/deathmatch/logic -o /tmp/CLuaArgument.o` *(fails: google/dense_hash_map: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68985a9ac204832f8c5d5a46e210549d