### PR TITLE
Consider mapped objects when checking if peds are on the ground

### DIFF
--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4679,8 +4679,12 @@ bool CClientPed::IsOnGround()
     if (m_pPlayerPed)
     {
         CPedSAInterface* pPedInterface = m_pPlayerPed->GetPedInterface();
-        if (pPedInterface && (pPedInterface->pedFlags.bIsStanding || pPedInterface->pContactEntity || GetContactEntity()))
-            return true;
+        if (pPedInterface)
+        {
+            CEntitySAInterface* pContact = pPedInterface->pContactEntity;
+            if ((pContact && pContact->nType == ENTITY_TYPE_OBJECT) || (!pContact && pPedInterface->pedFlags.bIsStanding))
+                return true;
+        }
     }
 
     CVector vecPosition;

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -31,6 +31,7 @@
 #include <game/TaskJumpFall.h>
 #include <game/TaskPhysicalResponse.h>
 #include <game/TaskAttack.h>
+#include <game_sa/CPedSA.h>
 #include "enums/VehicleType.h"
 
 using std::list;
@@ -4677,7 +4678,8 @@ bool CClientPed::IsOnGround()
 {
     if (m_pPlayerPed)
     {
-        if (m_pPlayerPed->IsOnGround() || m_pPlayerPed->IsStandingOnEntity() || GetContactEntity())
+        CPedSAInterface* pPedInterface = m_pPlayerPed->GetPedInterface();
+        if (pPedInterface && (pPedInterface->pedFlags.bIsStanding || pPedInterface->pContactEntity || GetContactEntity()))
             return true;
     }
 

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -31,7 +31,7 @@
 #include <game/TaskJumpFall.h>
 #include <game/TaskPhysicalResponse.h>
 #include <game/TaskAttack.h>
-#include <game_sa/CPedSA.h>
+#include "../../../game_sa/CPedSA.h"
 #include "enums/VehicleType.h"
 
 using std::list;

--- a/Client/mods/deathmatch/logic/CClientPed.cpp
+++ b/Client/mods/deathmatch/logic/CClientPed.cpp
@@ -4675,6 +4675,12 @@ float CClientPed::GetDistanceFromGround()
 
 bool CClientPed::IsOnGround()
 {
+    if (m_pPlayerPed)
+    {
+        if (m_pPlayerPed->IsOnGround() || m_pPlayerPed->IsStandingOnEntity() || GetContactEntity())
+            return true;
+    }
+
     CVector vecPosition;
     GetPosition(vecPosition);
     float fGroundLevel = static_cast<float>(g_pGame->GetWorld()->FindGroundZFor3DPosition(&vecPosition));


### PR DESCRIPTION
## Summary
- Account for contact entities and engine ground state before falling back to terrain checks in `CClientPed::IsOnGround`

## Testing
- `./linux-build.sh --config=debug --cores=1` (fails: x86_64-linux-gnu-g++-10: not found)


------
https://chatgpt.com/codex/tasks/task_e_689a3f529460832f98c13dcd9d600f2c