### PR TITLE
Allow cancelEvent for onElementDataChange

### DIFF
--- a/Server/mods/deathmatch/logic/CElement.cpp
+++ b/Server/mods/deathmatch/logic/CElement.cpp
@@ -709,22 +709,24 @@ bool CElement::GetCustomDataBool(const char* szName, bool& bOut, bool bInheritDa
     return false;
 }
 
-void CElement::SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
+bool CElement::SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType, CPlayer* pClient, bool bTriggerEvent)
 {
     assert(szName);
     if (strlen(szName) > MAX_CUSTOMDATA_NAME_LENGTH)
     {
         // Don't allow it to be set if the name is too long
         CLogger::ErrorPrintf("Custom data name too long (%s)\n", *SStringX(szName).Left(MAX_CUSTOMDATA_NAME_LENGTH + 1));
-        return;
+        return false;
     }
 
-    // Grab the old variable
+    // Grab the old variable and sync type
     CLuaArgument       oldVariable;
+    ESyncType          oldSyncType = ESyncType::LOCAL;
     const SCustomData* pData = m_CustomData.Get(szName);
     if (pData)
     {
         oldVariable = pData->Variable;
+        oldSyncType = pData->syncType;
     }
 
     // Set the new data
@@ -737,18 +739,27 @@ void CElement::SetCustomData(const char* szName, const CLuaArgument& Variable, E
         Arguments.PushString(szName);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(Variable);
-        CallEvent("onElementDataChange", Arguments, pClient);
+        if (!CallEvent("onElementDataChange", Arguments, pClient))
+        {
+            // Event was cancelled, restore previous value
+            if (pData)
+                m_CustomData.Set(szName, oldVariable, oldSyncType);
+            else
+                m_CustomData.Delete(szName);
+            return false;
+        }
     }
+    return true;
 }
 
-void CElement::DeleteCustomData(const char* szName)
+bool CElement::DeleteCustomData(const char* szName)
 {
     // Grab the old variable
     SCustomData* pData = m_CustomData.Get(szName);
     if (pData)
     {
-        CLuaArgument oldVariable;
-        oldVariable = pData->Variable;
+        CLuaArgument oldVariable = pData->Variable;
+        ESyncType    oldSyncType = pData->syncType;
 
         // Delete the custom data
         m_CustomData.Delete(szName);
@@ -758,8 +769,15 @@ void CElement::DeleteCustomData(const char* szName)
         Arguments.PushString(szName);
         Arguments.PushArgument(oldVariable);
         Arguments.PushArgument(CLuaArgument());            // Use nil as the new value to indicate the data has been removed
-        CallEvent("onElementDataChange", Arguments);
+        if (!CallEvent("onElementDataChange", Arguments))
+        {
+            // Event was cancelled, restore previous value
+            m_CustomData.Set(szName, oldVariable, oldSyncType);
+            return false;
+        }
+        return true;
     }
+    return false;
 }
 
 // Used to send the root element data when a player joins

--- a/Server/mods/deathmatch/logic/CElement.h
+++ b/Server/mods/deathmatch/logic/CElement.h
@@ -144,9 +144,9 @@ public:
     bool           GetCustomDataInt(const char* szName, int& iOut, bool bInheritData);
     bool           GetCustomDataFloat(const char* szName, float& fOut, bool bInheritData);
     bool           GetCustomDataBool(const char* szName, bool& bOut, bool bInheritData);
-    void           SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
+    bool           SetCustomData(const char* szName, const CLuaArgument& Variable, ESyncType syncType = ESyncType::BROADCAST, CPlayer* pClient = NULL,
                                  bool bTriggerEvent = true);
-    void           DeleteCustomData(const char* szName);
+    bool           DeleteCustomData(const char* szName);
     void           SendAllCustomData(CPlayer* pPlayer);
 
     CXMLNode* OutputToXML(CXMLNode* pNode);

--- a/Server/mods/deathmatch/logic/CGame.cpp
+++ b/Server/mods/deathmatch/logic/CGame.cpp
@@ -2730,25 +2730,45 @@ void CGame::Packet_CustomData(CCustomDataPacket& Packet)
                 return;
             }
 
-            if (lastSyncType != ESyncType::LOCAL)
+            if (pElement->SetCustomData(szName, Value, lastSyncType, pSourcePlayer))
             {
-                // Tell our clients to update their data. Send to everyone but the one we got this packet from.
+                if (lastSyncType != ESyncType::LOCAL)
+                {
+                    // Tell our clients to update their data. Send to everyone but the one we got this packet from.
+                    unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
+                    CBitStream     BitStream;
+                    BitStream.pBitStream->WriteCompressed(usNameLength);
+                    BitStream.pBitStream->Write(szName, usNameLength);
+                    Value.WriteToBitStream(*BitStream.pBitStream);
+                    if (lastSyncType == ESyncType::BROADCAST)
+                        m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pSourcePlayer);
+                    else
+                        m_pPlayerManager->BroadcastOnlySubscribed(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pElement, szName,
+                                                                  pSourcePlayer);
+
+                    CPerfStatEventPacketUsage::GetSingleton()->UpdateElementDataUsageRelayed(szName, m_pPlayerManager->Count(),
+                                                                                            BitStream.pBitStream->GetNumberOfBytesUsed());
+                }
+            }
+            else
+            {
+                // Event was cancelled; sync the authoritative value back to the source player
                 unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
                 CBitStream     BitStream;
                 BitStream.pBitStream->WriteCompressed(usNameLength);
                 BitStream.pBitStream->Write(szName, usNameLength);
-                Value.WriteToBitStream(*BitStream.pBitStream);
-                if (lastSyncType == ESyncType::BROADCAST)
-                    m_pPlayerManager->BroadcastOnlyJoined(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pSourcePlayer);
+
+                if (CLuaArgument* pServerValue = pElement->GetCustomData(szName, false))
+                {
+                    pServerValue->WriteToBitStream(*BitStream.pBitStream);
+                    pSourcePlayer->Send(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream));
+                }
                 else
-                    m_pPlayerManager->BroadcastOnlySubscribed(CElementRPCPacket(pElement, SET_ELEMENT_DATA, *BitStream.pBitStream), pElement, szName,
-                                                              pSourcePlayer);
-
-                CPerfStatEventPacketUsage::GetSingleton()->UpdateElementDataUsageRelayed(szName, m_pPlayerManager->Count(),
-                                                                                         BitStream.pBitStream->GetNumberOfBytesUsed());
+                {
+                    BitStream.pBitStream->WriteBit(false);
+                    pSourcePlayer->Send(CElementRPCPacket(pElement, REMOVE_ELEMENT_DATA, *BitStream.pBitStream));
+                }
             }
-
-            pElement->SetCustomData(szName, Value, lastSyncType, pSourcePlayer);
         }
     }
 }

--- a/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
+++ b/Server/mods/deathmatch/logic/CStaticFunctionDefinitions.cpp
@@ -1014,6 +1014,9 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
 
     if (!pCurrentVariable || *pCurrentVariable != Variable || lastSyncType != syncType)
     {
+        if (!pElement->SetCustomData(szName, Variable, syncType))
+            return false;
+
         if (syncType != ESyncType::LOCAL)
         {
             // Tell our clients to update their data
@@ -1034,8 +1037,6 @@ bool CStaticFunctionDefinitions::SetElementData(CElement* pElement, const char* 
         if (lastSyncType == ESyncType::SUBSCRIBE && syncType != ESyncType::SUBSCRIBE)
             m_pPlayerManager->ClearElementData(pElement, szName);
 
-        // Set its custom data
-        pElement->SetCustomData(szName, Variable, syncType);
         return true;
     }
     return false;
@@ -1050,6 +1051,9 @@ bool CStaticFunctionDefinitions::RemoveElementData(CElement* pElement, const cha
     // Check it exists
     if (pElement->GetCustomData(szName, false))
     {
+        if (!pElement->DeleteCustomData(szName))
+            return false;
+
         // Tell our clients to update their data
         unsigned short usNameLength = static_cast<unsigned short>(strlen(szName));
         CBitStream     BitStream;
@@ -1060,9 +1064,6 @@ bool CStaticFunctionDefinitions::RemoveElementData(CElement* pElement, const cha
 
         // Clean up after the data removal
         m_pPlayerManager->ClearElementData(pElement, szName);
-
-        // Delete here
-        pElement->DeleteCustomData(szName);
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Support cancelling element data changes via `cancelEvent`
- Revert element data when the change is cancelled
- Only broadcast element data updates when not cancelled
- Send the cancelling player the authoritative element data when their change is rejected

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c04e56430c832f9fe4a69af8d24193